### PR TITLE
Update parse_test_res.py to fix end_signal

### DIFF
--- a/parse_test_res.py
+++ b/parse_test_res.py
@@ -167,7 +167,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    end_signal = "Finished training"
+    end_signal = "Finish training"
     if args.test_log:
         end_signal = "=> result"
 


### PR DESCRIPTION
Current parse_test_res.py is not working well because of the wrong end_signal, which needs to be changed to `Finish training`