### PR TITLE
torresyu_pr

### DIFF
--- a/scripts/cocoop/base2new_test.sh
+++ b/scripts/cocoop/base2new_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ../..
+# cd ../..
 
 # custom config
 DATA=/path/to/datasets

--- a/scripts/cocoop/base2new_train.sh
+++ b/scripts/cocoop/base2new_train.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ../..
+# cd ../..
 
 # custom config
 DATA=/path/to/datasets

--- a/scripts/cocoop/xd_test.sh
+++ b/scripts/cocoop/xd_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ../..
+# cd ../..
 
 # custom config
 DATA=/path/to/datasets

--- a/scripts/cocoop/xd_train.sh
+++ b/scripts/cocoop/xd_train.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ../..
+# cd ../..
 
 # custom config
 DATA=/path/to/datasets


### PR DESCRIPTION
Dear Kaiyang,
I find a bug in the shells for CoCoOp. I think a correct way is to remove the top line "cd ../../" in the .sh scripts, or it will raise "train.py no such file" error. Thanks.